### PR TITLE
Cleanup, consistency and tabs => spaces for compatability

### DIFF
--- a/app/actions/LoadSearch.js
+++ b/app/actions/LoadSearch.js
@@ -1,13 +1,14 @@
-
 'use strict';
 
 var debug = require('debug')('app:action:loadapp');
 
 module.exports = function(context, payload, done) {
-	debug('executing load search %s', JSON.stringify(payload));
-	context.service.read('search', {type:'track', q: payload.query.q}, null, function(data) {
-		context.dispatch('SEARCH_TRACK', data );
-		done();
-	});
+  debug('executing load search %s', JSON.stringify(payload));
+  context.service.read('search', {
+    type:'track',
+    q: payload.query.q
+  }, null, function(data) {
+    context.dispatch('SEARCH_TRACK', data);
+    done();
+  });
 };
-

--- a/app/actions/LoadTrack.js
+++ b/app/actions/LoadTrack.js
@@ -1,13 +1,11 @@
-
 'use strict';
 
 var debug = require('debug')('app:action:loadtrack');
 
 module.exports = function(context, payload, done) {
-	debug('executing load track %s', JSON.stringify(payload));
-	context.service.read('tracks/'+payload.params.id, null, null, function(data) {
-		context.dispatch('LOAD_TRACK', data );
-		done();
-	});
+  debug('executing load track %s', JSON.stringify(payload));
+  context.service.read('tracks/' + payload.params.id, null, null, function(data) {
+    context.dispatch('LOAD_TRACK', data);
+    done();
+  });
 };
-

--- a/app/components/SpotifyListTracks.jsx
+++ b/app/components/SpotifyListTracks.jsx
@@ -1,67 +1,70 @@
-
 'use strict';
 
 var React = require('react');
 var Router = require('react-router');
 var Link = Router.Link;
 var warn = require('debug')('app:component:spotifylisttracks:warn');
+
 var SpotifyAlbumCover = React.createClass({
-	render: function() {	
-		var url;
-		try { 
-			url = this.props.model.images[1].url;
-		} catch(e) {
-			warn('album missing covere image', this.props.model);
-			return false;
-		}
-		return this.transferPropsTo(
-			<figure>
-				<img className='img-responsive img-rounded' src={url}/>
-			</figure>
-		);
-	}
+  render: function() {
+    var url;
+    try {
+      url = this.props.model.images[1].url;
+    } catch(e) {
+      warn('album missing cover image', this.props.model);
+      return false;
+    }
+    return this.transferPropsTo(
+      <figure>
+        <img className='img-responsive img-rounded' src={url} />
+      </figure>
+    );
+  }
 });
 
 var SpotifyTrack = React.createClass({
-	mixins: [Router.State],
-	render: function() {
-		if(!this.props.model) {
-			return false;
-		}
-		
-		var model = this.props.model;
-		var query = this.getQuery();
-		
-		return (
-			<article className='row'>
-				<Link to="track" params={model} query={query}>
-				<SpotifyAlbumCover className='col-xs-3' model={model.album} />
-				<div className='col-xs-9'>
-					<h2 className='h5'>{model.album.name}</h2>
-					<h1 className='h4'>{model.name}</h1>
-				</div>
-				</Link>
-			</article>
-		);
-	}
+  mixins: [Router.State],
+  render: function() {
+    if (!this.props.model) {
+      return false;
+    }
+
+    var model = this.props.model;
+    var query = this.getQuery();
+
+    return (
+      <article className='row'>
+        <Link to="track" params={model} query={query}>
+        <SpotifyAlbumCover className='col-xs-3' model={model.album} />
+        <div className='col-xs-9'>
+          <h2 className='h5'>{model.album.name}</h2>
+          <h1 className='h4'>{model.name}</h1>
+        </div>
+        </Link>
+      </article>
+    );
+  }
 });
-	
+
 module.exports = React.createClass({
-	displayName: 'SpotifyListTracks',
-	render: function() {
-		if(!this.props.model) {
-			return false;
-		}
-		var model = this.props.model;
-		var meta = this.props.meta;
-		return (
-		<ul className='list-group'>
-		{model.map(function (item) {
-			return <li key={item.id} className='list-group-item'>
-				<SpotifyTrack model={item} meta={meta}/>
-			</li>;
-		})}
-		</ul>
-		);
-	}
+  displayName: 'SpotifyListTracks',
+  render: function() {
+    if (!this.props.model || !this.props.model.map) {
+      return false;
+    }
+
+    var model = this.props.model;
+    var meta = this.props.meta;
+
+    return (
+      <ul className='list-group'>
+        {model.map(function(item) {
+          return (
+            <li key={item.id} className='list-group-item'>
+              <SpotifyTrack model={item} meta={meta} />
+            </li>);
+        })}
+      </ul>
+    );
+  }
 });

--- a/app/components/SpotifyMessage.jsx
+++ b/app/components/SpotifyMessage.jsx
@@ -1,17 +1,17 @@
-
 'use strict';
 
-var React		= require('react');
+var React = require('react');
 
 module.exports = React.createClass({
-	displayName: 'SpotifyMessage',
-	render: function() {
-		if(!this.props.value) {
-			return false;
-		}
-		return (
-			<div className='alert alert-info' role='alert'>{this.props.value}</div>
-		);
-	}
+  displayName: 'SpotifyMessage',
+  render: function() {
+    if (!this.props.value) {
+      return false;
+    }
+    return (
+      <div className='alert alert-info' role='alert'>
+        {this.props.value}
+      </div>
+    );
+  }
 });
-

--- a/app/components/SpotifySearch.jsx
+++ b/app/components/SpotifySearch.jsx
@@ -1,51 +1,47 @@
-
 'use strict';
 
-var React		= require('react');
+var React = require('react');
 var Router = require('react-router');
 var Navigation = Router.Navigation;
 var LoadSearch = require('../actions/LoadSearch');
 
 module.exports = React.createClass({
-	displayName: 'SpotifySearch',
-	mixins: [Navigation],
-	propTypes: {
-		value: React.PropTypes.string
-	},
-	handleChange: function(event) {
+  displayName: 'SpotifySearch',
+  mixins: [Navigation],
+  propTypes: {
+    value: React.PropTypes.string
+  },
+  handleChange: function(event) {
+    var value = event.target.value;
+    var context = this.props.context;
 
-		var value = event.target.value;
-		var context = this.props.context;
-	
-		context.executeAction(LoadSearch, { query: { q: value } });
-		this.transitionTo('/', null, {q:value}); 
-		this.setState({
-			value: value
-		});
-
-	},
-	getInitialState: function() {
-		return {
-			value: this.props.value
-		};
-	},
-	render: function() {
-		return (
-			<form method='GET'>
-				<div className='input-group'>
-					<input 
-						type='text'
-						className='form-control'
-						name='q'
-						value={this.state.value}
-						onChange={this.handleChange}
-						autoComplete='off' />
-					<span className='input-group-btn'>
-						<button className='btn btn-default' type='submit'>Go!</button>
-					</span>
-				</div>
-			</form>
-		);
-	}
+    context.executeAction(LoadSearch, { query: { q: value } });
+    this.transitionTo('/', null, { q:value });
+    this.setState({
+      value: value
+    });
+  },
+  getInitialState: function() {
+    return {
+      value: this.props.value
+    };
+  },
+  render: function() {
+    return (
+      <form method='GET'>
+        <div className='input-group'>
+          <input
+               type='text'
+               className='form-control'
+               name='q'
+               value={this.state.value}
+               onChange={this.handleChange}
+               autoComplete='off' />
+          <span className='input-group-btn'>
+            <button className='btn btn-default' type='submit'>Go!</button>
+          </span>
+        </div>
+      </form>
+    );
+  }
 });
-

--- a/app/components/SpotifyTrack.jsx
+++ b/app/components/SpotifyTrack.jsx
@@ -1,4 +1,3 @@
- 
 'use strict';
 
 var React = require('react');
@@ -6,41 +5,41 @@ var Router = require('react-router');
 var Link = Router.Link;
 
 var SpotifyAlbumCover = React.createClass({
-	render: function() {	
-		var url;
-		try { 
-			url = this.props.model.images[1].url;
-		} catch(e) {
-			return false;
-		}
-		return this.transferPropsTo(
-			<figure>
-				<img className='img-responsive img-rounded' src={url}/>
-			</figure>
-		);
-	}
+  render: function() {
+    var url;
+    try {
+      url = this.props.model.images[1].url;
+    } catch(e) {
+      return false;
+    }
+    return this.transferPropsTo(
+      <figure>
+        <img className='img-responsive img-rounded' src={url} />
+      </figure>
+    );
+  }
 });
 
 module.exports = React.createClass({
-	mixins: [Router.State],
-	render: function() {
-		if(!this.props.model) {
-			return false;
-		}
-		
-		var model = this.props.model;
-		var query = this.getQuery();
-		
-		return (
-			<article className='row'>
-				<Link to="/" query={query}>
-				<SpotifyAlbumCover className='col-xs-3' model={model.album} />
-				<div className='col-xs-9'>
-					<h2 className='h5'>{model.album.name}</h2>
-					<h1 className='h4'>{model.name}</h1>
-				</div>
-				</Link>
-			</article>
-		);
-	}
-});	
+  mixins: [Router.State],
+  render: function() {
+    if (!this.props.model) {
+      return false;
+    }
+
+    var model = this.props.model;
+    var query = this.getQuery();
+
+    return (
+      <article className='row'>
+        <Link to="/" query={query}>
+        <SpotifyAlbumCover className='col-xs-3' model={model.album} />
+        <div className='col-xs-9'>
+          <h2 className='h5'>{model.album.name}</h2>
+          <h1 className='h4'>{model.name}</h1>
+        </div>
+        </Link>
+      </article>
+    );
+  }
+});

--- a/app/components/routeHandlers/SearchTrack.jsx
+++ b/app/components/routeHandlers/SearchTrack.jsx
@@ -1,54 +1,48 @@
 'use strict';
 
-var React		= require('react');
+var React   = require('react');
 var Router = require('react-router');
 var StoreMixin = require('fluxible-app').StoreMixin;
-var DataStore = require('../../stores/DataStore');
 var SpotifySearch = require('../SpotifySearch.jsx');
 var SpotifyMessage = require('../SpotifyMessage.jsx');
 var SpotifyListTracks = require('../SpotifyListTracks.jsx');
 
-
 module.exports = React.createClass({
-	displayName: 'ViewTrack',			
-	mixins: [Router.State, StoreMixin],
-	statics: {
-		loadAction: require('../../actions/LoadSearch'),
-		storeListeners: ['DataStore']
-	},
-	getStateFromStores: function() {
-		var store = this.props.context.getStore(DataStore);
-		return {
-			message: store.getMessage(),
-			tracks: store.getTracks()
-		};
-	},
-	getInitialState: function() {
-		return this.getStateFromStores();
-	},
-	render: function() {
-		var tracks = this.state.tracks;
-		var message = this.state.message;
-		var query = this.getQuery().q;
-		var meta = {
-			query: query
-		};
-		return (
-			<div className='spotify-search'>
-			<SpotifySearch value={query} context={this.props.context}/>
-			<SpotifyMessage value={message}/>
-			<SpotifyListTracks model={tracks} meta={meta}/>
-			</div>
-		);
-	},
-
-	/**
-	 * Event handler for 'change' events coming from the stores
-	 */
-	onChange: function() {
-		this.setState(this.getStateFromStores());
-	}
-
+  displayName: 'ViewTrack',
+  mixins: [Router.State, StoreMixin],
+  statics: {
+    loadAction: require('../../actions/LoadSearch'),
+    storeListeners: ['DataStore']
+  },
+  getStateFromStores: function() {
+    var store = this.props.context.getStore('DataStore');
+    return {
+      message: store.getMessage(),
+      tracks: store.getTracks()
+    };
+  },
+  getInitialState: function() {
+    return this.getStateFromStores();
+  },
+  /**
+   * Event handler for 'change' events coming from the stores
+   */
+  onChange: function() {
+    this.setState(this.getStateFromStores());
+  },
+  render: function() {
+    var tracks = this.state.tracks;
+    var message = this.state.message;
+    var query = this.getQuery().q;
+    var meta = {
+      query: query
+    };
+    return (
+      <div className='spotify-search'>
+        <SpotifySearch value={query} context={this.props.context} />
+        <SpotifyMessage value={message} />
+        <SpotifyListTracks model={tracks} meta={meta} />
+      </div>
+    );
+  }
 });
-
-

--- a/app/components/routeHandlers/ViewTrack.jsx
+++ b/app/components/routeHandlers/ViewTrack.jsx
@@ -1,42 +1,40 @@
 'use strict';
 
-var React		= require('react');
+var React   = require('react');
 var Router = require('react-router');
 var StoreMixin = require('fluxible-app').StoreMixin;
-var DataStore = require('../../stores/DataStore');
 var SpotifyTrack =  require('../SpotifyTrack.jsx');
 
 module.exports = React.createClass({
-	displayName: 'ViewTrack',			
-	mixins: [Router.State, StoreMixin],
-	statics: {
-		loadAction: require('../../actions/LoadTrack'),
-		storeListeners: ['DataStore']
-	},
-	getStateFromStores: function() {
-		var store = this.props.context.getStore(DataStore);
-		return {
-			tracks: store.getTracks()
-		};
-	},
-	getInitialState: function() {
-		return this.getStateFromStores();
-	},
-	render: function() {
-		
-		var track = this.state.tracks[0];
-		if(!track) { return false; }
+  displayName: 'ViewTrack',
+  mixins: [Router.State, StoreMixin],
+  statics: {
+    loadAction: require('../../actions/LoadTrack'),
+    storeListeners: ['DataStore']
+  },
+  getStateFromStores: function() {
+    var store = this.props.context.getStore('DataStore');
+    return {
+      tracks: store.getTracks()
+    };
+  },
+  getInitialState: function() {
+    return this.getStateFromStores();
+  },
+  render: function() {
+    if (!this.state.tracks || !this.state.tracks.length) {
+      return false;
+    }
 
-		return (
-			<div className='spotify-search'>
-			<SpotifyTrack model={track}/>
-			</div>
-		);
-	},
-	onChange: function() {
-		this.setState(this.getStateFromStores());
-	}
+    var track = this.state.tracks[0];
 
+    return (
+      <div className='spotify-search'>
+        <SpotifyTrack model={track} />
+      </div>
+    );
+  },
+  onChange: function() {
+    this.setState(this.getStateFromStores());
+  }
 });
-
-

--- a/app/components/routeHandlers/app.jsx
+++ b/app/components/routeHandlers/app.jsx
@@ -1,21 +1,19 @@
-
 'use strict';
 
-var React		= require('react'),
-		Router = require('react-router'),
-		RouteHandler = Router.RouteHandler;
+var React   = require('react'),
+    Router = require('react-router'),
+    RouteHandler = Router.RouteHandler;
 
 module.exports = React.createClass({
-	displayName: 'AppHandler',			
-	render: function() {
-		return (
-			<div className='container-fluid'>
-				<div className='jumbotron'>
-					<h1>Spotify React search</h1>
-				</div>
-				<RouteHandler context={this.props.context}/>
-			</div>
-		);
-	}
+  displayName: 'AppHandler',
+  render: function() {
+    return (
+      <div className='container-fluid'>
+        <div className='jumbotron'>
+          <h1>Spotify React search</h1>
+        </div>
+        <RouteHandler context={this.props.context} />
+      </div>
+    );
+  }
 });
-

--- a/app/index.js
+++ b/app/index.js
@@ -1,9 +1,8 @@
-
 'use strict';
 
 var FluxibleApp = require('fluxible-app');
 var app = new FluxibleApp({
-	appComponent: require('./routes.jsx')
+  appComponent: require('./routes.jsx')
 });
 
 app.uid = '__example';
@@ -14,4 +13,3 @@ app.plug(require('./plugins/EnvPlugin'));
 app.plug(require('./plugins/ServicePlugin'));
 
 module.exports = app;
-

--- a/app/mixins/PersistentStoreMixin.js
+++ b/app/mixins/PersistentStoreMixin.js
@@ -5,23 +5,23 @@
 var debug = require('debug')('app:mixin:persistentstoremixin');
 var warn = require('debug')('app:mixin:persistentstoremixin:warn');
 
-module.exports = {	
-	dehydrate: function() {
-		debug('dehydrating %s', this.constructor.storeName);
-		if(!this.data) {
-			warn('missing data object');
-			return;
-		}
-		return Object.keys(this.data).reduce(function(result, prop) {
-			result[prop] = this.data[prop];
-			return result;
-		}.bind(this), {});
-	},
+module.exports = {
+  dehydrate: function() {
+    debug('dehydrating %s', this.constructor.storeName);
+    if (!this.data) {
+      warn('missing data object');
+      return;
+    }
+    return Object.keys(this.data).reduce(function(result, prop) {
+      result[prop] = this.data[prop];
+      return result;
+    }.bind(this), {});
+  },
 
-	rehydrate: function (state) {
-		debug('rehydrating %s', this.constructor.storeName);
-		Object.keys(state).forEach(function (prop) {
-			this.data[prop] = state[prop];
-		}.bind(this));
-	}
+  rehydrate: function (state) {
+    debug('rehydrating %s', this.constructor.storeName);
+    Object.keys(state).forEach(function (prop) {
+      this.data[prop] = state[prop];
+    }.bind(this));
+  }
 };

--- a/app/plugins/EnvPlugin.js
+++ b/app/plugins/EnvPlugin.js
@@ -1,40 +1,39 @@
-
 'use strict';
 
 module.exports = {
-	name: 'EnvPlugin',
-	plugContext: function (options) {
-		var env = options.env || {};
-		
-		var get = function (name) {
-			return env[name];
-		};
+  name: 'EnvPlugin',
+  plugContext: function(options) {
+    var env = options.env || {};
 
-		var isDevelopment = function() {
-			return env.NODE_ENV === 'development';
-		};
+    var get = function(name) {
+      return env[name];
+    };
 
-		return {
-			plugComponentContext: function (componentContext) {
-				componentContext.getEnv = get;
-				componentContext.isDevelopment = isDevelopment;
-			},
-			plugActionContext: function (actionContext) {
-				actionContext.getEnv = get;
-				actionContext.isDevelopment = isDevelopment;
-			},
-			plugStoreContext: function (storeContext) {
-				storeContext.getEnv = get;
-				storeContext.isDevelopment = isDevelopment;
-			},
-			dehydrate: function () {
-				return {
-					env: env	
-				};
-			},
-			rehydrate: function (state) {
-				env = state.env;
-			}
-		};
-	}
+    var isDevelopment = function() {
+      return env.NODE_ENV === 'development';
+    };
+
+    return {
+      plugComponentContext: function(componentContext) {
+        componentContext.getEnv = get;
+        componentContext.isDevelopment = isDevelopment;
+      },
+      plugActionContext: function(actionContext) {
+        actionContext.getEnv = get;
+        actionContext.isDevelopment = isDevelopment;
+      },
+      plugStoreContext: function(storeContext) {
+        storeContext.getEnv = get;
+        storeContext.isDevelopment = isDevelopment;
+      },
+      dehydrate: function() {
+        return {
+          env: env
+        };
+      },
+      rehydrate: function(state) {
+        env = state.env;
+      }
+    };
+  }
 };

--- a/app/plugins/ServicePlugin.js
+++ b/app/plugins/ServicePlugin.js
@@ -1,37 +1,36 @@
-
 'use strict';
 
 var request = require('superagent');
 
 module.exports = {
-	name: 'ServicePlugin',
-	plugContext: function (options) {
-		var api = options.api;
-		return {
-			plugActionContext: function (actionContext) {
-				actionContext.service = {
-					read: function(resource, params, config, done) {
-						var endpoint = api + '/' + resource;
-						request
-							.get(endpoint)
-							.query(params)
-							.type('json')
-							.end(function(err, res){
-								if(err) {
-									done(JSON.parse(err));
-								} else {
-									done(JSON.parse(res.text));
-								}
-							});
-					}
-				};
-			},
-			dehydrate: function () {
-				return { api: api };
-			},
-			rehydrate: function (state) {
-				api = state.api;
-			}
-		};
-	}
+  name: 'ServicePlugin',
+  plugContext: function(options) {
+    var api = options.api;
+    return {
+      plugActionContext: function(actionContext) {
+        actionContext.service = {
+          read: function(resource, params, config, done) {
+            var endpoint = api + '/' + resource;
+            request
+              .get(endpoint)
+              .query(params)
+              .type('json')
+              .end(function(err, res){
+                if (err) {
+                  done(JSON.parse(err));
+                } else {
+                  done(JSON.parse(res.text));
+                }
+              });
+          }
+        };
+      },
+      dehydrate: function() {
+        return { api: api };
+      },
+      rehydrate: function(state) {
+        api = state.api;
+      }
+    };
+  }
 };

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -5,14 +5,14 @@ var ReactRouter = require('react-router');
 var Route = ReactRouter.Route;
 var DefaultRoute = ReactRouter.DefaultRoute;
 
-// rout handler components
-var App	= require('./components/routeHandlers/app.jsx');
+// route handler components
+var App = require('./components/routeHandlers/app.jsx');
 var ViewTrack = require('./components/routeHandlers/ViewTrack.jsx');
 var SearchTrack = require('./components/routeHandlers/SearchTrack.jsx');
 
 module.exports = (
-	<Route path="" handler={App}>
-		<DefaultRoute handler={SearchTrack}/>
-		<Route path="track/:id" name="track" handler={ViewTrack}/>
-	</Route>
+  <Route path="" handler={App}>
+    <DefaultRoute handler={SearchTrack}/>
+    <Route path="track/:id" name="track" handler={ViewTrack}/>
+  </Route>
 );

--- a/app/stores/DataStore.js
+++ b/app/stores/DataStore.js
@@ -7,55 +7,53 @@ var PersistentStoreMixin = require('../mixins/PersistentStoreMixin');
 
 // This is a very optimistic data store.
 var DataStore = createStore({
-	storeName: 'DataStore',
-	mixins: [PersistentStoreMixin],
-	initialize: function() {
-		this.data = {};
-	},
-	handlers: {
-		SEARCH_TRACK: function(data) {
-			if(data.error && data.error.message) {
-				this.data = {
-					message: data.error.message,
-					tracks: []
-				};
-			} else {
-				this.data = data;
-			}
-			this.emitChange();
-		},
-		LOAD_TRACK: function(data) {
-			if(data.error && data.error.message) {
-				this.data = {
-					message: data.error.message,
-					tracks: []
-				};
-			} else {
-				this.data = {
-					tracks: {
-						items: [data]
-					}
-				};
-			}
-			this.emitChange();
-		}	
-	},
-	getTracks: function() {
-		try {
-			return this.data.tracks.items || [];
-		} catch (e) {
-			return [];
-		}
-	},
-	getMessage: function() {
-		try {
-			return this.data.message;
-		} catch (e) {
-			return [];
-		}
-	}
-
+  storeName: 'DataStore',
+  mixins: [PersistentStoreMixin],
+  initialize: function() {
+    this.data = {};
+  },
+  handlers: {
+    SEARCH_TRACK: function(data) {
+      if (data.error && data.error.message) {
+        this.data = {
+          message: data.error.message,
+          tracks: []
+        };
+      } else {
+        this.data = data;
+      }
+      this.emitChange();
+    },
+    LOAD_TRACK: function(data) {
+      if (data.error && data.error.message) {
+        this.data = {
+          message: data.error.message,
+          tracks: []
+        };
+      } else {
+        this.data = {
+          tracks: {
+            items: [].concat(data)
+          }
+        };
+      }
+      this.emitChange();
+    }
+  },
+  getTracks: function() {
+    try {
+      return this.data.tracks.items || [];
+    } catch (e) {
+      return [];
+    }
+  },
+  getMessage: function() {
+    try {
+      return this.data.message;
+    } catch (e) {
+      return [];
+    }
+  }
 });
 
 module.exports = DataStore;
-

--- a/app/views/layout.hbs
+++ b/app/views/layout.hbs
@@ -3,32 +3,32 @@
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
-	<head>
-		<meta charset="utf-8">
-		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<title>Example app</title>
-		<meta name="description" content="">
-		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<meta name="robots" content="noindex, nofollow">
-		<script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.min.js"></script>
-		<link href="/resources/css/bootstrap.min.css" rel="stylesheet">
-		<style>
-		.spotify-search > * + * {
-			margin-top: 1em;
-		}
-		</style>
-	</head>
-	<body>
-		<div id="{{{uid}}}">
-			{{{html}}}
-		</div>
-		<script>
-			{{{state}}}
-		</script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.0.3/es5-shim.min.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.0.3/es5-sham.min.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/react/0.12.0/react.js"></script>
-		<script src="/resources/js/client.bundle.js"></script>
-	</body>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Example app</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.2/modernizr.min.js"></script>
+    <link href="/resources/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+    .spotify-search > * + * {
+      margin-top: 1em;
+    }
+    </style>
+  </head>
+  <body>
+    <div id="{{{uid}}}">
+      {{{html}}}
+    </div>
+    <script>
+      {{{state}}}
+    </script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.0.3/es5-shim.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.0.3/es5-sham.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/react/0.12.0/react.js"></script>
+    <script src="/resources/js/client.bundle.js"></script>
+  </body>
 </html>

--- a/client.js
+++ b/client.js
@@ -1,40 +1,38 @@
 /* jshint node:false */
 (function() {
-		
-	'use strict';
-	
-	var debug = require('debug')('app:client:debug');
-	var error = require('debug')('app:client:error');
-	
-	try {
-		var React = require('react');
-		var Router = require('react-router');
-		var app = require('./app');
-		var dehydratedState = window[app.uid];
 
-		// Debug.enable('*');
-		debug('rehydrating app');
-		app.rehydrate(dehydratedState, function (err, context) {
-				if (err) {
-					error(err);
-					return;
-				}
-				debug('React Rendering');
-				Router.run(app.getAppComponent(), Router.HistoryLocation, function (Handler, state) {
-					React.render(
-						React.createElement(
-							Handler,
-							{context: context.getComponentContext()}
-						),
-						document.getElementById(app.uid)
-					);
-					debug('React Rendered');
-				});
+  'use strict';
 
-		});
-	} catch (err) {
-		error(err);
-	}
+  var debug = require('debug')('app:client:debug');
+  var error = require('debug')('app:client:error');
 
+  try {
+    var React = require('react');
+    var Router = require('react-router');
+    var app = require('./app');
+    var dehydratedState = window[app.uid];
+
+    // Debug.enable('*');
+    debug('rehydrating app');
+    app.rehydrate(dehydratedState, function(err, context) {
+        if (err) {
+          error(err);
+          return;
+        }
+        debug('React Rendering');
+        Router.run(app.getAppComponent(),Router.HistoryLocation, function(Handler, state) {
+          React.render(
+            React.createElement(
+              Handler,
+              { context: context.getComponentContext() }
+            ),
+            document.getElementById(app.uid)
+          );
+          debug('React Rendered');
+        });
+
+    });
+  } catch (err) {
+    error(err);
+  }
 }).call(this);
-

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,26 +5,26 @@
 module.exports = {
   context: __dirname,
   entry: {
-		client: ['./client.js']
-	},
-	plugins: [
-		// new webpack.IgnorePlugin(/^react\//),
-	],
-  output: {
-		path: '/resources/js',
-    filename: '[name].bundle.js',
-		chunkFilename: '[id].bundle.js',
-		hashDigestLength: 32
+    client: ['./client.js']
   },
-	module: {
-		loaders: [
-			{ test: /\.jsx$/, loader: 'jsx-loader' }
-		]
-	},
-	devtool: '#source-map',
+  plugins: [
+    // new webpack.IgnorePlugin(/^react\//),
+  ],
+  output: {
+    path: '/resources/js',
+    filename: '[name].bundle.js',
+    chunkFilename: '[id].bundle.js',
+    hashDigestLength: 32
+  },
+  module: {
+    loaders: [
+      { test: /\.jsx$/, loader: 'jsx-loader' }
+    ]
+  },
+  devtool: '#source-map',
   externals: {
-		jquery: "jQuery",
-		react: "React",
-		modernizr: "Modernizr"
-	}
+    jquery: "jQuery",
+    react: "React",
+    modernizr: "Modernizr"
+  }
 };


### PR DESCRIPTION
* All functions are now consistently written ```function(...)``` (no extra space before argument list)
* Added extra space on self-closing tags, e.g. ```<SomeComponent propOne={one} />``` rather than ```<SomeComponent propOne={one}/>``` for clarity
* All tabs are now **two** spaces to ensure proper alignment across systems
* Removed verbose *datastore* requires
* Added some additional render sanity checks
* Removed extra line breaks that served no purpose (e.g. *hard* statement ending invalidating the need for newline)
* Fixed a typo
* Cut some long lines to better adhere to 80-col rule-of-thumb